### PR TITLE
fix: sort third party license files

### DIFF
--- a/make/license.mk
+++ b/make/license.mk
@@ -57,7 +57,7 @@ third-party-licenses: go-licenses
 	@echo "Collecting third-party licenses..."
 	@$(GO_LICENSES) save ./... --save_path=third_party_licenses
 	@echo "Generating THIRD_PARTY_NOTICES..."
-	@find third_party_licenses -type f -iname "LICENSE*" | while read -r license; do \
+	@find third_party_licenses -type f -iname "LICENSE*" | sort | while read -r license; do \
 		echo "---"; \
 		echo "## $$(basename $$(dirname "$$license"))"; \
 		echo ""; \


### PR DESCRIPTION
otherwise find output is non-deterministic which
will lead to issues when validating licenses in CI