### PR TITLE
feat: adjust conditions for when to trigger job that updates versions in net-op's hack/release.yaml

### DIFF
--- a/.github/workflows/fork-ci-reusable.yml
+++ b/.github/workflows/fork-ci-reusable.yml
@@ -63,7 +63,7 @@ on:
     outputs:
       docker-tag:
         description: "Docker tag used to build images"
-        value: ${{ jobs.determine_docker_registry_tag_and_check_branch.outputs.docker_tag }}
+        value: ${{ jobs.determine_docker_registry_and_tag.outputs.docker_tag }}
 
 jobs:
   determine_ref:
@@ -73,7 +73,7 @@ jobs:
     outputs:
       github_ref_name: ${{ inputs.ref-name || github.ref_name }}
       github_ref_type: ${{ inputs.ref-type || github.ref_type }}
-  determine_docker_registry_tag_and_check_branch:
+  determine_docker_registry_and_tag:
     needs: determine_ref
     runs-on: ubuntu-latest
     env:
@@ -92,40 +92,25 @@ jobs:
         run: |
           echo DOCKER_REGISTRY=${{ inputs.registry-internal }} | tee -a $GITHUB_ENV
           echo DOCKER_TAG=$REF_NAME | tee -a $GITHUB_ENV
-      - name: Chceck if on *latest* release branch
-        if: needs.determine_ref.outputs.github_ref_type == 'branch'
-        run: |
-          latest_release_branch=$(git branch -ar | grep -E 'network-operator-[0-9.]+x' | cut -d '/' -f 2- | sort -V | tail -1)  # example: network-operator-25.10.x
-          echo "Latest release branch is $latest_release_branch"
-          echo "Current branch is $REF_NAME"
-
-          if [ "$REF_NAME" != "$latest_release_branch" ]; then
-            echo "Not on latest release branch. Exiting this job."
-            exit 0
-          fi
-
-          echo IS_LATEST_RELEASE_BRANCH=true | tee -a $GITHUB_ENV
-      - name: Store docker registry, tag, and branch for following jobs
-        id: store-docker-registry-tag-and-branch-check
+      - name: Store docker registry and tag for following jobs
+        id: store-docker-registry-and-tag
         run: |
           echo DOCKER_REGISTRY=$DOCKER_REGISTRY | tee -a $GITHUB_OUTPUT
           echo DOCKER_TAG=$DOCKER_TAG | tee -a $GITHUB_OUTPUT
-          echo IS_LATEST_RELEASE_BRANCH=$IS_LATEST_RELEASE_BRANCH | tee -a $GITHUB_OUTPUT
     outputs:
-      docker_registry: ${{ steps.store-docker-registry-tag-and-branch-check.outputs.DOCKER_REGISTRY }}
-      docker_tag: ${{ steps.store-docker-registry-tag-and-branch-check.outputs.DOCKER_TAG }}
-      is_latest_release_branch: ${{ steps.store-docker-registry-tag-and-branch-check.outputs.IS_LATEST_RELEASE_BRANCH }}
+      docker_registry: ${{ steps.store-docker-registry-and-tag.outputs.DOCKER_REGISTRY }}
+      docker_tag: ${{ steps.store-docker-registry-and-tag.outputs.DOCKER_TAG }}
 
   build_and_push_images:
     needs:
       - determine_ref
-      - determine_docker_registry_tag_and_check_branch
+      - determine_docker_registry_and_tag
     runs-on: linux-amd64-cpu4
     env:
       REF_NAME: ${{ needs.determine_ref.outputs.github_ref_name }}
       BUILD_PLATFORMS: linux/amd64,linux/arm64
-      DOCKER_REGISTRY: ${{ needs.determine_docker_registry_tag_and_check_branch.outputs.docker_registry }}
-      DOCKER_TAG: ${{ needs.determine_docker_registry_tag_and_check_branch.outputs.docker_tag }}
+      DOCKER_REGISTRY: ${{ needs.determine_docker_registry_and_tag.outputs.docker_registry }}
+      DOCKER_TAG: ${{ needs.determine_docker_registry_and_tag.outputs.docker_tag }}
       GOPROXY: ${{ secrets.goproxy || 'direct' }}
       BASE_IMAGE_DOCA_FULL_RT_HOST: nvcr.io/nvidia/doca/doca:3.2.1-full-rt-host
       BASE_IMAGE_DOCA_BASE_RT_HOST: nvcr.io/nvidia/doca/doca:3.2.1-base-rt-host
@@ -185,12 +170,12 @@ jobs:
   update_component_version_in_network_operator:
     needs:
       - determine_ref
-      - determine_docker_registry_tag_and_check_branch
+      - determine_docker_registry_and_tag
       - build_and_push_images
-    if: needs.determine_docker_registry_tag_and_check_branch.outputs.is_latest_release_branch == 'true'
+    if: needs.determine_ref.outputs.github_ref_type == 'branch'
     runs-on: ubuntu-latest
     env:
-      GIT_SHA_SHORT: ${{ needs.determine_docker_registry_tag_and_check_branch.outputs.docker_tag }}
+      GIT_SHA_SHORT: ${{ needs.determine_docker_registry_and_tag.outputs.docker_tag }}
       REF_NAME: ${{ github.ref_name }}
       GH_TOKEN: ${{ secrets.cicd-gh-token }}
     steps:
@@ -239,6 +224,6 @@ jobs:
           gh pr create ${{ env.TEST_RUN == 'true' && '--dry-run' || '' }} \
             --head "$UPDATE_BRANCH" \
             --base master \
-            --title "ci: update ${{ github.event.repository.name }} version to $GIT_SHA_SHORT" \
-            --body "Automated CI update for component '${{ github.event.repository.name }}', created by [GitHub actions reusable workflow run $GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." \
+            --title "ci: update ${{ github.event.repository.name }} version to $GIT_SHA_SHORT (of branch $REF_NAME)" \
+            --body "Automated CI update for component '${{ github.event.repository.name }}', created by [GitHub actions reusable workflow run $GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) for release branch $REF_NAME." \
             --reviewer e0ne --reviewer almaslennikov --reviewer rollandf --reviewer heyvister1


### PR DESCRIPTION
adjusted trigger conditions for `update_component_version_in_network_operator` job:
- trigger on any release branch (like discussed/requested).
- but (logical `AND`) only if the triggering `ref_typ` is "_branch_".
- the resulting PR (to update `hack/release.yaml`) shall detail in its title the source/triggering **release branch name** - allowing R&D to make informed decisions if to merge it (most probably yes, for latest release branch [e.g. _`26.1.x`_]) - or not (maybe, for previous release branch [e.g. _`25.10.x`_]).