### PR TITLE
ci: allow patch Docker updates in release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     commit-message:
       prefix: "chore:"
     ignore:
-      - dependency-name: "nvstaging/doca/doca"
-        versions:
-          - ">=3.5"
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Allows Dependabot Docker version updates to provide patch bumps while blocking semver major/minor bumps.

This supports Network Operator GA release branches: the release workflow will clone this default Docker update entry into `target-branch: network-operator-<major>.<minor>.x`, and the cloned entry needs to allow DOCA patch tags instead of ignoring all `nvstaging/doca/doca >=3.5` updates.

Validation:
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`\n- `git diff --check`