### PR TITLE
ci: skip fork-ci updates for tagged source commits

### DIFF
--- a/.github/workflows/fork-ci-reusable.yml
+++ b/.github/workflows/fork-ci-reusable.yml
@@ -78,6 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ env.REF_NAME }}
           fetch-depth: 0
       - if: needs.determine_ref.outputs.github_ref_type == 'branch'
         name: Determine docker registry and tag (when git branch)
@@ -92,16 +93,61 @@ jobs:
       - name: Store docker registry and tag for following jobs
         id: store-docker-registry-and-tag
         run: |
+          echo GIT_SHA=$(git rev-parse HEAD) | tee -a $GITHUB_OUTPUT
           echo DOCKER_REGISTRY=$DOCKER_REGISTRY | tee -a $GITHUB_OUTPUT
           echo DOCKER_TAG=$DOCKER_TAG | tee -a $GITHUB_OUTPUT
     outputs:
+      git_sha: ${{ steps.store-docker-registry-and-tag.outputs.GIT_SHA }}
       docker_registry: ${{ steps.store-docker-registry-and-tag.outputs.DOCKER_REGISTRY }}
       docker_tag: ${{ steps.store-docker-registry-and-tag.outputs.DOCKER_TAG }}
 
+  source_release_tag_guard:
+    needs:
+      - determine_ref
+    runs-on: ubuntu-latest
+    outputs:
+      has_release_tag: ${{ steps.check-release-tags.outputs.HAS_RELEASE_TAG }}
+      release_tags: ${{ steps.check-release-tags.outputs.RELEASE_TAGS }}
+    steps:
+      - if: needs.determine_ref.outputs.github_ref_type != 'tag'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.determine_ref.outputs.github_ref_name }}
+          fetch-depth: 0
+      - name: Check whether source commit already has a Network Operator release tag
+        id: check-release-tags
+        run: |
+          if [ "${{ needs.determine_ref.outputs.github_ref_type }}" = "tag" ]; then
+            echo "Source release tag guard is skipped for tag refs."
+            echo HAS_RELEASE_TAG=false | tee -a "$GITHUB_OUTPUT"
+            echo RELEASE_TAGS= | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --force --tags origin
+          release_tags=$(git tag --points-at HEAD --list 'network-operator-*' | sort)
+
+          if [ -n "$release_tags" ]; then
+            echo "Source commit already has Network Operator release tag(s):"
+            echo "$release_tags"
+            echo HAS_RELEASE_TAG=true | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "Source commit does not have Network Operator release tags."
+            echo HAS_RELEASE_TAG=false | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo 'RELEASE_TAGS<<EOF'
+            echo "$release_tags"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
   build_and_push_images:
+    if: needs.determine_ref.outputs.github_ref_type == 'tag' || needs.source_release_tag_guard.outputs.has_release_tag != 'true'
     needs:
       - determine_ref
       - determine_docker_registry_and_tag
+      - source_release_tag_guard
     runs-on: linux-amd64-cpu4
     permissions:
       contents: read
@@ -144,7 +190,7 @@ jobs:
           echo "BUILD_PLATFORMS=$NEW_BUILD_PLATFORMS" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.github_ref_name }}
+          ref: ${{ env.REF_NAME }}
       - name: Setup Go Proxy
         id: setup-go-proxy
         uses: nv-gha-runners/setup-artifactory-go-proxy@main
@@ -177,12 +223,14 @@ jobs:
     needs:
       - determine_ref
       - determine_docker_registry_and_tag
+      - source_release_tag_guard
       - build_and_push_images
-    if: needs.determine_ref.outputs.github_ref_type == 'branch'
+    if: needs.determine_ref.outputs.github_ref_type == 'branch' && needs.source_release_tag_guard.outputs.has_release_tag != 'true'
     runs-on: ubuntu-latest
     env:
+      GIT_SHA_FULL: ${{ needs.determine_docker_registry_and_tag.outputs.git_sha }}
       GIT_SHA_SHORT: ${{ needs.determine_docker_registry_and_tag.outputs.docker_tag }}
-      REF_NAME: ${{ github.ref_name }}
+      REF_NAME: ${{ needs.determine_ref.outputs.github_ref_name }}
       GH_TOKEN: ${{ secrets.cicd-gh-token }}
     steps:
       - uses: actions/checkout@v4
@@ -200,10 +248,17 @@ jobs:
       - name: Update version in hack/release.yaml
         id: update-hack-release-yaml
         run: |
+          component_version_file="$RUNNER_TEMP/component-versions.env"
+          : > "$component_version_file"
+
           for component_name in $COMPONENT_NAMES; do
+            old_version=$(yq -r ".$component_name.version" hack/release.yaml)
+            echo "$component_name=$old_version" >> "$component_version_file"
             echo "Updating version for $component_name"
             yq -i ".$component_name.version = \"${GIT_SHA_SHORT}\"" hack/release.yaml
           done
+          echo COMPONENT_VERSION_FILE=$component_version_file | tee -a $GITHUB_ENV
+
           make release-build
 
           if git diff --exit-code --color=always; then
@@ -211,6 +266,53 @@ jobs:
           else
             echo UPDATE_BRANCH=ci/update-${{ github.event.repository.name }}-version-to-$GIT_SHA_SHORT | tee -a $GITHUB_ENV
           fi
+      - name: Prepare pull request body
+        if: env.UPDATE_BRANCH != ''
+        run: |
+          pr_body_file="$RUNNER_TEMP/pr-body.md"
+
+          {
+            echo "Automated CI update for component '${{ github.event.repository.name }}', created by [GitHub actions reusable workflow run $GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) for release branch $REF_NAME."
+            echo
+            echo "## Component updates"
+            while IFS='=' read -r component_name old_version; do
+              echo
+              echo "### $component_name"
+              echo
+              echo "- Previous version in \`hack/release.yaml\`: \`$old_version\`"
+              echo "- New version: \`$GIT_SHA_SHORT\`"
+              echo
+              echo "Commits from \`$old_version\` to \`$GIT_SHA_SHORT\`:"
+
+              if compare_json=$(gh api "repos/$GITHUB_REPOSITORY/compare/$old_version...$GIT_SHA_FULL" 2>/dev/null); then
+                commit_count=$(echo "$compare_json" | jq '.commits | length')
+                if [ "$commit_count" -eq 0 ]; then
+                  echo "- No commits found in this range."
+                else
+                  echo "$compare_json" | jq -r '.commits[] | @base64' | while read -r commit_data; do
+                    commit_json=$(echo "$commit_data" | base64 --decode)
+                    sha=$(echo "$commit_json" | jq -r '.sha')
+                    short_sha=$(echo "$sha" | cut -c1-7)
+                    subject=$(echo "$commit_json" | jq -r '.commit.message | split("\n")[0]')
+                    commit_url=$(echo "$commit_json" | jq -r '.html_url')
+                    pr_json=$(gh api -H "Accept: application/vnd.github+json" "repos/$GITHUB_REPOSITORY/commits/$sha/pulls" 2>/dev/null || echo '[]')
+                    pr_url=$(echo "$pr_json" | jq -r '.[0].html_url // ""')
+                    pr_number=$(echo "$pr_json" | jq -r '.[0].number // ""')
+
+                    if [ -n "$pr_url" ]; then
+                      echo "- [$short_sha]($commit_url) $subject ([#$pr_number]($pr_url))"
+                    else
+                      echo "- [$short_sha]($commit_url) $subject"
+                    fi
+                  done
+                fi
+              else
+                echo "- Unable to generate a commit diff for this range in \`$GITHUB_REPOSITORY\`."
+              fi
+            done < "$COMPONENT_VERSION_FILE"
+          } > "$pr_body_file"
+
+          echo PR_BODY_FILE=$pr_body_file | tee -a $GITHUB_ENV
       - name: Create CI branch
         if: env.UPDATE_BRANCH != ''
         run: |
@@ -231,14 +333,15 @@ jobs:
             --head "$UPDATE_BRANCH" \
             --base master \
             --title "ci: update ${{ github.event.repository.name }} version to $GIT_SHA_SHORT (of branch $REF_NAME)" \
-            --body "Automated CI update for component '${{ github.event.repository.name }}', created by [GitHub actions reusable workflow run $GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) for release branch $REF_NAME." \
+            --body-file "$PR_BODY_FILE" \
             --reviewer e0ne --reviewer almaslennikov --reviewer rollandf --reviewer heyvister1
 
   update-issue-status:
-    if: always()
+    if: ${{ always() && !(needs.determine_ref.outputs.github_ref_type != 'tag' && needs.source_release_tag_guard.outputs.has_release_tag == 'true') }}
     needs:
       - determine_ref
       - determine_docker_registry_and_tag
+      - source_release_tag_guard
       - build_and_push_images
       - update_component_version_in_network_operator
     uses: ./.github/workflows/issue-status-update-reusable.yml

--- a/.github/workflows/test-fork-ci-callee.yml
+++ b/.github/workflows/test-fork-ci-callee.yml
@@ -11,6 +11,10 @@ on:
       ref_type:
         description: "Type of ref to use (tag or branch)"
         required: true
+      has_release_tag:
+        description: "Whether to add a network-operator-* tag to the branch commit"
+        required: false
+        default: "false"
       distinct_id:
         description: "Unique identifier for the run"
 
@@ -26,9 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Configure git author
+        run: |
+          git config user.name "nvidia-ci-cd"
+          git config user.email "svc-cloud-orch-gh@nvidia.com"
       - if: inputs.ref_type == 'tag'
         name: Create release tag and branch
         run: |
+          git commit --allow-empty -m "test: isolate ${{ inputs.ref_name }}"
           git tag ${{ inputs.ref_name }}
           git push origin ${{ inputs.ref_name }} -f
           # We need to cut the release branch from the 'network-operator' master branch
@@ -43,8 +52,15 @@ jobs:
         name: Create release branch
         run: |
           git checkout -b ${{ inputs.ref_name }}
+          git commit --allow-empty -m "test: isolate ${{ inputs.ref_name }}"
           git push origin ${{ inputs.ref_name }} -f
           echo BRANCH=${{ inputs.ref_name }} | tee -a $GITHUB_ENV
+          if [ "${{ inputs.has_release_tag }}" = "true" ]; then
+            release_tag="${{ inputs.ref_name }}-tagged"
+            git tag "$release_tag"
+            git push origin "$release_tag" -f
+            echo TAG=$release_tag | tee -a $GITHUB_ENV
+          fi
       - name: Store branch and tag
         id: store-tag-branch
         run: |
@@ -73,6 +89,7 @@ jobs:
       cicd-gh-token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
 
   validate-docker-images-built:
+    if: inputs.ref_type == 'tag' || inputs.has_release_tag != 'true'
     needs: call-reusable-ci-fork-workflow
     runs-on: ubuntu-latest
     env:
@@ -138,7 +155,7 @@ jobs:
           echo "All docker images successfully verified!"
 
   validate-pr-with-updated-version-open:
-    if: inputs.ref_type == 'branch'
+    if: inputs.ref_type == 'branch' && inputs.has_release_tag != 'true'
     needs: call-reusable-ci-fork-workflow
     runs-on: ubuntu-latest
     env:
@@ -165,7 +182,7 @@ jobs:
       pr-number: ${{ steps.validate_pr_open.outputs.PR_NUMBER }}
 
   validate-pr-changes:
-    if: inputs.ref_type == 'branch'
+    if: inputs.ref_type == 'branch' && inputs.has_release_tag != 'true'
     needs:
       - call-reusable-ci-fork-workflow
       - validate-pr-with-updated-version-open
@@ -189,6 +206,14 @@ jobs:
             echo "Error: PR body does not contain the current workflow run URL ($CURRENT_RUN_URL)" >&2
             exit 1
           fi
+          if ! echo "$PR_BODY" | grep -Fq 'Previous version in `hack/release.yaml`: `v0.1.18`'; then
+            echo "Error: PR body does not contain the previous component version" >&2
+            exit 1
+          fi
+          if ! echo "$PR_BODY" | grep -Fq 'Commits from `v0.1.18` to'; then
+            echo "Error: PR body does not contain the commit diff section" >&2
+            exit 1
+          fi
 
           make check-release-build
 
@@ -205,6 +230,21 @@ jobs:
               echo "Error: NicConfigurationConfigDaemon version is not set correctly in $RELEASE_FILE"; exit 1; \
           fi
 
+  validate-no-pr-opened-for-tagged-branch:
+    if: inputs.ref_type == 'branch' && inputs.has_release_tag == 'true'
+    needs: call-reusable-ci-fork-workflow
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Validate that no PR was opened for a branch commit that already has a release tag
+        run: |
+          OUTPUT=$(gh pr list --repo ${{ github.repository }} --search="state:open in:title ${{ needs.call-reusable-ci-fork-workflow.outputs.docker-tag }}" --json number)
+          if [ "$(echo "$OUTPUT" | jq 'length')" -ne 0 ]; then
+            echo "Error: expected no update PR for tagged branch commit, found: $OUTPUT" >&2
+            exit 1
+          fi
+
   cleanup:
     if: always()
     env:
@@ -214,6 +254,7 @@ jobs:
       - validate-docker-images-built
       - validate-pr-with-updated-version-open
       - validate-pr-changes
+      - validate-no-pr-opened-for-tagged-branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -226,20 +267,20 @@ jobs:
         run: |
           if [ -n "$PR_NUMBER" ]; then
             echo "Closing PR #$PR_NUMBER..."
-            gh pr close "$PR_NUMBER"
+            gh pr close "$PR_NUMBER" || true
           fi
 
           if [ -n "$PR_BRANCH" ]; then
-          echo "Deleting pr branch $PR_BRANCH from origin..."
-          git push origin --delete "$PR_BRANCH"
+            echo "Deleting pr branch $PR_BRANCH from origin..."
+            git push origin --delete "$PR_BRANCH" || true
           fi
 
           if [ -n "$BRANCH" ]; then
             echo "Deleting branch $BRANCH from origin..."
-            git push origin --delete "$BRANCH"
+            git push origin --delete "$BRANCH" || true
           fi
           if [ -n "$TAG" ]; then
             echo "Deleting tag $TAG from origin..."
-            git push origin --delete refs/tags/$TAG
+            git push origin --delete refs/tags/$TAG || true
           fi
           echo "Test completed successfully - no cleanup needed since no test resources were created"

--- a/.github/workflows/test-fork-ci-dispatcher.yml
+++ b/.github/workflows/test-fork-ci-dispatcher.yml
@@ -16,12 +16,14 @@ jobs:
   test_workflow_fork_ci:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         configurations: [
           { "ref_name": "network-operator-11.1-beta.1", "ref_type": "tag" },
           { "ref_name": "network-operator-22.2-rc.1", "ref_type": "tag" },
           { "ref_name": "network-operator-33.3.1", "ref_type": "tag" },
-          { "ref_name": "network-operator-44.4.x", "ref_type": "branch" }
+          { "ref_name": "network-operator-44.4.x", "ref_type": "branch" },
+          { "ref_name": "network-operator-55.5.x", "ref_type": "branch", "has_release_tag": "true" }
         ]
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.configurations.ref_name }}


### PR DESCRIPTION
## Summary
- skip fork-ci side effects for non-tag refs when the source commit already has a `network-operator-*` tag
- include previous `hack/release.yaml` component versions and commit/PR links in network-operator update PR bodies
- extend fork-ci sandbox coverage for normal branch updates and tagged-branch no-op behavior
- isolate each fork-ci matrix case on its own empty commit so release tags from one case cannot affect another case
- make fork-ci test cleanup idempotent and disable dispatcher fail-fast so one cleanup race does not cancel the rest of the matrix

## Verification
- YAML parse check for the three changed workflow files
- `git diff --check`