### PR TITLE
feat: add reusable Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge-reusable.yml
+++ b/.github/workflows/dependabot-auto-merge-reusable.yml
@@ -1,0 +1,223 @@
+name: Reusable Dependabot Auto-Merge
+
+on:
+  workflow_call:
+    inputs:
+      merge-method:
+        description: "Merge method to use: merge, squash, or rebase"
+        required: false
+        type: string
+        default: merge
+      target-branch:
+        description: "Branch Dependabot pull requests must target; defaults to the caller repository's default branch"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      gh-token:
+        description: "Optional GitHub App or personal access token; defaults to the caller's GITHUB_TOKEN"
+        required: false
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Dependabot auto-merge decision
+    if: >-
+      (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') ||
+      (github.event.pull_request.user.login == 'dependabot[bot]' &&
+       github.event.pull_request.base.ref == (inputs.target-branch || github.event.repository.default_branch) &&
+       !github.event.pull_request.draft)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Merge conflict-free pull requests with green checks
+        env:
+          AUTO_MERGE_JOB_NAME: Dependabot auto-merge decision
+          CALLER_WORKFLOW: ${{ github.workflow }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.gh-token || github.token }}
+          MERGE_METHOD: ${{ inputs.merge-method }}
+          TARGET_BRANCH: ${{ inputs.target-branch || github.event.repository.default_branch }}
+        run: |
+          case "$MERGE_METHOD" in
+            merge)
+              merge_flag=--merge
+              ;;
+            squash)
+              merge_flag=--squash
+              ;;
+            rebase)
+              merge_flag=--rebase
+              ;;
+            *)
+              echo "Unsupported merge method: $MERGE_METHOD" >&2
+              exit 1
+              ;;
+          esac
+
+          process_pr() {
+            local pr_number=$1
+            local max_attempts=$2
+            local pr author base_ref draft expected_head_sha pr_url state
+            local checks checks_status other_checks check_count
+            local pending_count unsuccessful_count stable_complete_snapshots
+            local attempt mergeable
+
+            pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")
+            author=$(jq -r '.user.login' <<< "$pr")
+            base_ref=$(jq -r '.base.ref' <<< "$pr")
+            draft=$(jq -r '.draft' <<< "$pr")
+            expected_head_sha=$(jq -r '.head.sha' <<< "$pr")
+            pr_url=$(jq -r '.html_url' <<< "$pr")
+            state=$(jq -r '.state' <<< "$pr")
+
+            if [ "$author" != "dependabot[bot]" ] || \
+               [ "$base_ref" != "$TARGET_BRANCH" ] || \
+               [ "$draft" = "true" ] || \
+               [ "$state" != "open" ]; then
+              echo "Pull request #$pr_number is not an eligible open Dependabot update; skipping."
+              return 0
+            fi
+
+            stable_complete_snapshots=0
+
+            for attempt in $(seq 1 "$max_attempts"); do
+              checks_status=0
+              checks=$(gh pr checks "$pr_url" \
+                --json name,state,bucket,link,workflow) || checks_status=$?
+
+              if [ "$checks_status" -ne 0 ] && \
+                 [ "$checks_status" -ne 1 ] && \
+                 [ "$checks_status" -ne 8 ]; then
+                echo "Failed to read checks for pull request #$pr_number (exit $checks_status)." >&2
+                return "$checks_status"
+              fi
+
+              other_checks=$(jq -c \
+                --arg workflow "$CALLER_WORKFLOW" \
+                --arg job "$AUTO_MERGE_JOB_NAME" \
+                '[.[] | select(
+                  ((.workflow == $workflow) and
+                   ((.name == $job) or (.name | endswith(" / " + $job))))
+                  | not
+                )]' <<< "$checks")
+              check_count=$(jq 'length' <<< "$other_checks")
+              pending_count=$(jq \
+                '[.[] | select(.bucket == "pending")] | length' \
+                <<< "$other_checks")
+              unsuccessful_count=$(jq \
+                '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' \
+                <<< "$other_checks")
+
+              if [ "$check_count" -eq 0 ]; then
+                stable_complete_snapshots=0
+                echo "No other checks are registered for pull request #$pr_number yet (attempt $attempt/$max_attempts)."
+              elif [ "$unsuccessful_count" -gt 0 ]; then
+                echo "Pull request #$pr_number has unsuccessful checks; leaving it open:"
+                jq -r '.[] | "- \(.name): \(.bucket)"' <<< "$other_checks"
+                return 0
+              elif [ "$pending_count" -gt 0 ]; then
+                stable_complete_snapshots=0
+                echo "Waiting for checks on pull request #$pr_number (attempt $attempt/$max_attempts):"
+                jq -r '.[] | "- \(.name): \(.bucket)"' <<< "$other_checks"
+              else
+                stable_complete_snapshots=$((stable_complete_snapshots + 1))
+                echo "All $check_count other checks for pull request #$pr_number are green (stable snapshot $stable_complete_snapshots/2)."
+
+                if [ "$stable_complete_snapshots" -ge 2 ]; then
+                  break
+                fi
+              fi
+
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 10
+              fi
+            done
+
+            if [ "$stable_complete_snapshots" -lt 2 ]; then
+              echo "Pull request #$pr_number is not ready; a scheduled scan will retry it."
+              return 0
+            fi
+
+            pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")
+            author=$(jq -r '.user.login' <<< "$pr")
+            base_ref=$(jq -r '.base.ref' <<< "$pr")
+            draft=$(jq -r '.draft' <<< "$pr")
+            state=$(jq -r '.state' <<< "$pr")
+
+            if [ "$author" != "dependabot[bot]" ] || \
+               [ "$base_ref" != "$TARGET_BRANCH" ] || \
+               [ "$draft" = "true" ] || \
+               [ "$state" != "open" ]; then
+              echo "Pull request #$pr_number is no longer eligible; skipping."
+              return 0
+            fi
+
+            if [ "$(jq -r '.head.sha' <<< "$pr")" != "$expected_head_sha" ]; then
+              echo "Pull request #$pr_number changed while checks were evaluated; waiting for checks on the new head."
+              return 0
+            fi
+
+            for attempt in {1..12}; do
+              mergeable=$(gh pr view "$pr_url" --json mergeable --jq '.mergeable')
+
+              case "$mergeable" in
+                MERGEABLE)
+                  gh pr merge "$pr_url" "$merge_flag" --match-head-commit "$expected_head_sha"
+                  return 0
+                  ;;
+                CONFLICTING)
+                  echo "Dependabot pull request #$pr_number has merge conflicts; leaving it open."
+                  return 0
+                  ;;
+                UNKNOWN)
+                  echo "Mergeability for pull request #$pr_number is not ready yet (attempt $attempt/12)."
+                  sleep 5
+                  ;;
+                *)
+                  echo "Unexpected mergeability value for pull request #$pr_number: $mergeable" >&2
+                  return 1
+                  ;;
+              esac
+            done
+
+            echo "GitHub did not calculate mergeability for pull request #$pr_number; a scheduled scan will retry it."
+          }
+
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # Allow other checks time to register before evaluating the check set.
+            sleep 15
+            process_pr "$EVENT_PR_NUMBER" 150
+            exit 0
+          fi
+
+          mapfile -t pr_numbers < <(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --app dependabot \
+              --base "$TARGET_BRANCH" \
+              --state open \
+              --limit 100 \
+              --json number \
+              --jq '.[].number'
+          )
+
+          if [ "${#pr_numbers[@]}" -eq 0 ]; then
+            echo "No open Dependabot pull requests target branch $TARGET_BRANCH."
+            exit 0
+          fi
+
+          for pr_number in "${pr_numbers[@]}"; do
+            process_pr "$pr_number" 2
+          done

--- a/README.md
+++ b/README.md
@@ -22,6 +22,52 @@ When the logic of these workflows is changed, please add corresponding changes t
 * `test-fork-ci-dispatcher.yml`
 * `test-fork-sync.yml`
 
+## Dependabot pull requests
+
+The `dependabot-auto-merge-reusable.yml` workflow merges non-draft Dependabot pull requests that target the caller repository's current default branch. Before merging, it waits until every pull request check outside its own auto-merge job has completed successfully or been skipped, verifies that the checked head SHA has not changed, and confirms that the pull request has no merge conflicts. Pull requests with unsuccessful checks or conflicts are left open.
+
+Set the optional `target-branch` input to process a branch other than the caller repository's default branch:
+
+```yaml
+jobs:
+  dependabot-auto-merge:
+    uses: Mellanox/cloud-orchestration-reusable-workflows/.github/workflows/dependabot-auto-merge-reusable.yml@main
+    with:
+      target-branch: release-26.7
+```
+
+The scheduled trigger is important: it revisits eligible pull requests whose checks outlast the initial workflow run.
+
+Add a caller workflow to the consuming repository:
+
+```yaml
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+jobs:
+  dependabot-auto-merge:
+    uses: Mellanox/cloud-orchestration-reusable-workflows/.github/workflows/dependabot-auto-merge-reusable.yml@main
+```
+
+The reusable workflow uses the caller's `GITHUB_TOKEN` by default. Callers can pass a GitHub App or personal access token as the optional `gh-token` secret when merges must trigger additional workflow runs. The caller's permissions are the upper bound for a called workflow, so all five permissions shown above are required.
+
 ### Fork CI tests:
 These tests use the `cloud-orchestration-reusable-workflows` repo as a sandbox and create test branches / tags / PRs, and are [synchronized](https://github.com/Mellanox/cloud-orchestration-reusable-workflows/blob/main/.github/workflows/test-fork-ci-dispatcher.yml#L26) to avoid race conditions.
 The repo has a dummy `master` branch which is a copy of the corresponding branch of the [Network Operator's repo](https://github.com/Mellanox/network-operator). This is done to avoid testing clutter in the main repo. If needed, the branch can be updated.


### PR DESCRIPTION
## Summary

- add a generic `workflow_call` reusable for non-draft Dependabot pull requests
- scope processing to the caller repository's current default branch unless the optional `target-branch` input selects another branch
- wait for every check outside the reusable auto-merge job to complete successfully or be skipped, requiring two complete snapshots before proceeding
- support scheduled/manual retries for checks that outlast the initial run
- revalidate PR eligibility and the checked head SHA, then merge only when GitHub reports no conflicts
- support merge, squash, and rebase methods with an optional GitHub App or personal access token
- document the caller triggers, branch override, and required permissions

## Validation

- `actionlint` v1.7.12
- Ruby YAML parse
- `git diff --check`
- aggregate filter against NVIDIA/k8s-launch-kit PR #159: 8 other checks, 0 pending, 0 unsuccessful
- fixture check: another job in the same caller workflow remains in the aggregate while only the reusable auto-merge job is excluded
